### PR TITLE
Update plugin View files to works with 2.2.* version of Croogo

### DIFF
--- a/View/Albums/admin_form.ctp
+++ b/View/Albums/admin_form.ctp
@@ -16,7 +16,7 @@ if (empty($this->data['Album']['title'])) {
 $inputDefaults = $this->Form->settings;
 $inputClass = isset($inputDefaults['class']) ? $inputDefaults['class'] : null;
 if (empty($inputClass)):
-	$inputClass = $this->Layout->cssClass('formInput');
+	$inputClass = $this->Theme->getCssClass('formInput');
 endif;
 
 $this->start('actions');

--- a/View/Albums/admin_index.ctp
+++ b/View/Albums/admin_index.ctp
@@ -50,11 +50,11 @@ $this->append('table-body');
 		$actions[] = $this->Croogo->adminRowActions($album['Album']['id']);
 		$actions[] = $this->Croogo->adminRowAction('',
 			array('controller' => 'albums', 'action' => 'edit', $album['Album']['id']),
-			array('icon' => $_icons['update'], 'tooltip' => __d('gallery', 'Edit'))
+			array('icon' => $this->Theme->getIcon('update'), 'tooltip' => __d('gallery', 'Edit'))
 		);
 		$actions[] = $this->Croogo->adminRowAction('',
 			array('controller' => 'albums', 'action' => 'delete', $album['Album']['id']),
-			array('icon' => $_icons['delete'], 'tooltip' => __d('gallery', 'Delete')),
+			array('icon' => $this->Theme->getIcon('delete'), 'tooltip' => __d('gallery', 'Delete')),
 			__d('gallery', 'Are you sure you want to delete this album?')
 		);
 

--- a/View/Albums/admin_upload.ctp
+++ b/View/Albums/admin_upload.ctp
@@ -4,13 +4,13 @@ $this->extend('/Common/admin_index');
 
 $this->Html->css('/gallery/css/fileuploader', array('inline' => false));
 
-$thumbnailClass = $this->Layout->cssClass('thumbnailClass');
+$thumbnailClass = $this->Theme->getCssClass('thumbnailClass');
 $iPrefix = $this->Html->settings['iconDefaults']['classPrefix'];
 $iDefault = $this->Html->settings['iconDefaults']['classDefault'];
-$iDelete = "$iDefault " . $iPrefix . $_icons['delete'];
-$iEdit = "$iDefault " . $iPrefix . $_icons['update'];
-$iMoveUp = "$iDefault " . $iPrefix . $_icons['move-up'];
-$iMoveDown = "$iDefault " . $iPrefix . $_icons['move-down'];
+$iDelete = "$iDefault " . $iPrefix . $this->Theme->getIcon('delete');
+$iEdit = "$iDefault " . $iPrefix . $this->Theme->getIcon('update');
+$iMoveUp = "$iDefault " . $iPrefix . $this->Theme->getIcon('move-up');
+$iMoveDown = "$iDefault " . $iPrefix . $this->Theme->getIcon('move-down');
 
 $editUrl = $this->Html->link($album['Album']['title'], array(
 	'plugin' => 'gallery',
@@ -20,7 +20,7 @@ $editUrl = $this->Html->link($album['Album']['title'], array(
 ));
 
 $this->Html
-	->addCrumb('', '/admin', array('icon' => $_icons['home']))
+	->addCrumb('', '/admin', array('icon' => $this->Theme->getIcon('home')))
 	->addCrumb('Gallery')
 	->addCrumb(__d('gallery', 'Albums'), array(
 		'admin' => true,
@@ -68,8 +68,8 @@ $this->start('actions');
 	);
 $this->end();
 
-$rowClass = $this->Layout->cssClass('row');
-$columnFull = $this->Layout->cssClass('columnFull');
+$rowClass = $this->Theme->getCssClass('row');
+$columnFull = $this->Theme->getCssClass('columnFull');
 
 $photos = array();
 if (isset($album['Photo'])):

--- a/View/Elements/admin/album_actions.ctp
+++ b/View/Elements/admin/album_actions.ctp
@@ -4,7 +4,7 @@
 		array(
 			'rel' => $photo['id'],
 			'class' => 'remove red',
-			'icon' => $_icons['delete'],
+			'icon' => $this->Theme->getIcon('delete'),
 		)
 	);
 ?>
@@ -16,7 +16,7 @@
 		$photo['id'],
 	), array(
 		'class' => 'edit',
-		'icon' => $_icons['update'],
+		'icon' => $this->Theme->getIcon('update'),
 	));
 
 ?>
@@ -28,7 +28,7 @@
 		$photo['AlbumsPhoto']['id'],
 	), array(
 		'class' => 'up',
-		'icon' => $_icons['move-up'],
+		'icon' => $this->Theme->getIcon('move-up'),
 	));
 ?>
 
@@ -39,7 +39,7 @@
 		$photo['AlbumsPhoto']['id'],
 	), array(
 		'class' => 'down',
-		'icon' => $_icons['move-down'],
+		'icon' => $this->Theme->getIcon('move-down'),
 	));
 ?>
 </div>

--- a/View/Photos/admin_index.ctp
+++ b/View/Photos/admin_index.ctp
@@ -30,7 +30,7 @@ $this->append('table-body');
 		$actions[] = $this->Croogo->adminRowAction('',
 			array('controller' => 'photos', 'action' => 'edit', $attachment['Photo']['id']),
 			array(
-				'icon' => $_icons['update'],
+				'icon' => $this->Theme->getIcon('update'),
 				'tooltip' => __d('gallery', 'Edit')
 			)
 		);


### PR DESCRIPTION
Hi,
This is my first pull request ever on GitHub so please correct me if I did something wrong.
I did changes to some view files until `LayoutHelper::cssClass()` and `$_icons` are deprecated no more in Croogo 2.2.\* and it causes errors.
That works for me and I hope it will for others also.

Regards
